### PR TITLE
Add test for Last Will and Testament and fix topic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - "main"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - "main"
+      - "feature/**"
   pull_request:
-    branches: [ main ]
+    branches: 
+      - "main"
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@chrispyduck/homie-device",
+  "name": "@ngreatorex/homie-device",
   "description": "Homie Device for NodeJS",
-  "version": "0.1.1-unstable",
+  "version": "0.2.1-unstable",
   "author": {
     "name": "Chris Carlson",
     "url": "https://github.com/chrispyduck"

--- a/src/HomieDevice.ts
+++ b/src/HomieDevice.ts
@@ -85,7 +85,7 @@ export default class HomieDevice extends HomieTopologyRoot {
         payload: "lost",
         qos: 0,
         retain: true,
-        topic: `${this.name}/$state`,
+        topic: `${this.config.mqtt.base_topic}/${this.name}/$state`,
       },
     }) as mqtt.IClientOptions;
     // tslint:disable-next-line:whitespace

--- a/src/HomieDevice.ts
+++ b/src/HomieDevice.ts
@@ -85,7 +85,7 @@ export default class HomieDevice extends HomieTopologyRoot {
         payload: "lost",
         qos: 0,
         retain: true,
-        topic: `${this.config.mqtt.base_topic}/${this.name}/$state`,
+        topic: `${this.config.mqtt?.base_topic}/${this.name}/$state`,
       },
     }) as mqtt.IClientOptions;
     // tslint:disable-next-line:whitespace

--- a/test/1-HomieDevice.ts
+++ b/test/1-HomieDevice.ts
@@ -30,8 +30,8 @@ export const makeDevice = (config?: IHomieDeviceConfiguration): IHomieDeviceTest
   let mqttStub: MqttStub | undefined;
   config = makeDeviceConfig(_.merge(config, {
     mqtt: {
-      connectionFactory: () => {
-        mqttStub = MqttStub.connect({} as IClientOptions);
+      connectionFactory: (opts: IClientOptions) => {
+        mqttStub = MqttStub.connect(opts);
         return mqttStub as unknown as MqttClient;
       },
     },
@@ -79,6 +79,18 @@ describe("Homie Device", () => {
       if (test.device.isConnected) {
         test.device.end();
       }
+    });
+
+    it("passes will to MQTT client", () => {
+      const will = {
+        payload: "lost",
+        retain: true,
+        topic: `${test.deviceConfig.mqtt?.base_topic}/${test.deviceConfig.name}/$state`,
+      };
+      test.device.setup();
+
+      expect(test.mqtt.clientOptions).to.not.be.undefined;
+      expect(test.mqtt.clientOptions).to.have.property("will").to.include(will);
     });
 
     it("emits all device messages as 'message' events", (done) => {

--- a/test/mqttStub.ts
+++ b/test/mqttStub.ts
@@ -30,10 +30,8 @@ export default class MQTTClientStub extends EventEmitter {
 
   public publish = (topic: string, msg: string, opts: IClientPublishOptions): void => {
     this.publishedMsgs.push({ topic, msg, opts });
-    setTimeout(() => {
-      // Auto subscribe to all published messages
-      this.emit("message", topic, msg);
-    }, 1);
+    // Auto subscribe to all published messages
+    this.emit("message", topic, msg);
   }
 
   public end = (): void => {

--- a/test/mqttStub.ts
+++ b/test/mqttStub.ts
@@ -10,6 +10,8 @@ export type PublishedMessage = {
 
 export default class MQTTClientStub extends EventEmitter {
 
+  public readonly clientOptions: IClientOptions;
+
   public static connect = (opts: IClientOptions): MQTTClientStub => {
     const client = new MQTTClientStub(opts);
     setTimeout(() => {
@@ -22,6 +24,7 @@ export default class MQTTClientStub extends EventEmitter {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(_opts: IClientOptions) {
     super();
+    this.clientOptions = _opts;
     this.publishedMsgs = [];
   }
 


### PR DESCRIPTION
This PR is based on PR #15 from @BoBiene. I've added a unit test and fixed an error that occurs with TypeScript compilation in the original PR. 

I've also switched the unit tests' MQTT stub to emit message events synchronously to ensure that the message events are received and processed fully before the unit tests check the list of received messages. This fixes an intermittent failure in the unit tests.

Fixes #10.